### PR TITLE
Fix/widgets yml parsing

### DIFF
--- a/lib/watchdog/engine.rb
+++ b/lib/watchdog/engine.rb
@@ -12,9 +12,13 @@ module Watchdog
       path = File.join(Rails.root, WIDGETS_CONF_PATH)
 
       if File.exist? path
-        config = YAML.safe_load File.read(path)
+        begin
+          config = YAML.safe_load File.read(path)
+        rescue Psych::SyntaxError => e
+          raise "Your widgets configuration (at #{WIDGETS_CONF_PATH}) could not be parsed: #{e.message}"
+        end
       else
-        warn("You haven't declared any widgets in config/widgets.yml")
+        warn("You haven't written a configuration file (expected at: #{WIDGETS_CONF_PATH})")
         config = { widgets: [] }
       end
 

--- a/test/dummy/config/initializers/widgets.rb
+++ b/test/dummy/config/initializers/widgets.rb
@@ -1,4 +1,0 @@
-
-config = YAML.safe_load File.read(File.join(Rails.root, 'config', 'widgets.yml'))
-
-Rails.application.config.widgets = config

--- a/test/dummy/config/widgets.yml
+++ b/test/dummy/config/widgets.yml
@@ -10,4 +10,4 @@ widgets:
     title: 'Strike 2'
     subtitle: 'yolo'
     type: 'pie'
-    group: 'zendesk''
+    group: 'zendesk'


### PR DESCRIPTION
# Description
Remove the app widgets initializer and make the Watchdog initializer (which replaced the former) more resilient.